### PR TITLE
Add Linphone to "media-role.applications"

### DIFF
--- a/src/config/policy.lua.d/10-default-policy.lua
+++ b/src/config/policy.lua.d/10-default-policy.lua
@@ -28,7 +28,7 @@ bluetooth_policy.policy = {
   -- Application names correspond to application.name in stream properties.
   -- Applications which do not set media.role but which should be considered
   -- for role based profile switching can be specified here.
-  ["media-role.applications"] = { "Firefox", "Chromium input", "Google Chrome input", "Brave input", "Microsoft Edge input", "Vivaldi input", "ZOOM VoiceEngine", "Telegram Desktop" },
+  ["media-role.applications"] = { "Firefox", "Chromium input", "Google Chrome input", "Brave input", "Microsoft Edge input", "Vivaldi input", "ZOOM VoiceEngine", "Telegram Desktop", "linphone" },
 }
 
 function default_policy.enable()


### PR DESCRIPTION
I use Linphone (4.2.5) on my Debian testing notebook. It doesn't set any `media.role` property. I added it to `/etc/wireplumber/policy.lua.d/10-default-policy.lua` like that:
```
  -- Application names correspond to application.name in stream properties.
  -- Applications which do not set media.role but which should be considered
  -- for role based profile switching can be specified here.
  ["media-role.applications"] = { "Firefox", "Chromium input", "Google Chrome input", "Brave input", "Microsoft Edge input", "Vivaldi input", "ZOOM VoiceEngine", "Telegram Desktop", "linphone" },
}
```

Since it worked for me, I now want to propose to take this as default for future versions and other users.