### PR TITLE
docs: fix various codebase typos

### DIFF
--- a/docs/rst/daemon/configuration/components_and_profiles.rst
+++ b/docs/rst/daemon/configuration/components_and_profiles.rst
@@ -66,7 +66,7 @@ The main types of components are:
     A PipeWire module, which is also a shared library that can be loaded
     dynamically, but extends the functionality of the underlying *libpipewire*
     library. Loading PipeWire modules in the WirePlumber context can be useful
-    to load custom protocol extensions or to offload some funcitonality from
+    to load custom protocol extensions or to offload some functionality from
     the PipeWire daemon.
 
   * **virtual**

--- a/docs/rst/daemon/configuration/conf_file.rst
+++ b/docs/rst/daemon/configuration/conf_file.rst
@@ -204,7 +204,7 @@ by libpipewire to configure the PipeWire context:
   .. note::
 
      PipeWire modules can also be loaded as :ref:`components <config_components_and_profiles>`,
-     which may be preferrable since it allows you to load them conditionally
+     which may be preferable since it allows you to load them conditionally
      based on the profile and component dependencies.
 
   .. admonition:: Remember

--- a/docs/rst/daemon/locations.rst
+++ b/docs/rst/daemon/locations.rst
@@ -50,7 +50,7 @@ the first one has the highest priority and the last one has the lowest.
 
 .. note::
 
-   When the configuration directory is overriden with
+   When the configuration directory is overridden with
    ``WIREPLUMBER_CONFIG_DIR``, the default locations are ignored and
    configuration files are *only* looked up in the directories specified by this
    variable.
@@ -75,7 +75,7 @@ When WirePlumber loads a configuration file from the default locations, it will
 also load all configuration fragments that are present in all of the default
 locations, but following the reverse order of priority. This allows
 configuration fragments that are installed in more system-wide locations to be
-overriden by the system administrator or the users.
+overridden by the system administrator or the users.
 
 For example, assuming WirePlumber loads ``wireplumber.conf``, from any of the
 search locations, it will also locate and load the following fragments, in this

--- a/docs/rst/design/events_and_hooks.rst
+++ b/docs/rst/design/events_and_hooks.rst
@@ -3,7 +3,7 @@
 Events and Hooks
 ================
 
-Session management is all about reacting to events and taking neccessary
+Session management is all about reacting to events and taking necessary
 actions. This is why WirePlumber's logic is all built on events and hooks.
 
 Events
@@ -56,7 +56,7 @@ There are two main types of hooks: ``SimpleEventHook`` and ``AsyncEventHook``.
 * ``AsyncEventHook`` contains multiple functions, combined together in a state
   machine using ``WpTransition`` underneath. The hook is completed only after
   the state machine reaches its final state and this can take any amount of time
-  neccessary.
+  necessary.
 
 Every hook also has a name, which can be an arbitrary string of characters.
 Additionally, it has two arrays of names, which declare dependencies between

--- a/docs/rst/policies/smart_filters.rst
+++ b/docs/rst/policies/smart_filters.rst
@@ -14,7 +14,7 @@ chain, the policy will automatically link the stream with the first filter in
 the chain, and the last filter in the chain with the target node. This is done
 transparently to the client, allowing users to define a specific processing
 chain for a specific device without having to create setups with virtual sinks
-(or sources) that must be explicitly targetted by the clients.
+(or sources) that must be explicitly targeted by the clients.
 
 Filters, in general, are nodes that are placed in the middle of the graph and
 are used to modify the data that passes through them. For example, the

--- a/docs/rst/policies/software_dsp.rst
+++ b/docs/rst/policies/software_dsp.rst
@@ -18,7 +18,7 @@ by the vendor's proprietary userspace.
 WirePlumber's automatic software DSP mechanism aims to replicate this functionality in
 a standardised and configurable way. The target device sink/source is hidden from
 other PipeWire clients, and a virtual node is linked to it. This virtual
-node is then presented to clients as *the* node, allowing implementors to specify
+node is then presented to clients as *the* node, allowing implementers to specify
 any custom processing or routing in a way that is transparent to users, the kernel,
 and the hardware.
 

--- a/lib/wp/device.c
+++ b/lib/wp/device.c
@@ -313,8 +313,8 @@ spa_device_event_info (void *data, const struct spa_device_info *info)
   WpSpaDevice *self = WP_SPA_DEVICE (data);
 
   /*
-   * This is emited syncrhonously at the time we add the listener and
-   * before object_info is emited. It gives us additional properties
+   * This is emitted synchronously at the time we add the listener and
+   * before object_info is emitted. It gives us additional properties
    * about the device, like the "api.alsa.card.*" ones that are not
    * set by the monitor
    */

--- a/lib/wp/json-utils.c
+++ b/lib/wp/json-utils.c
@@ -53,7 +53,7 @@ match_rules_cb (void *data, const char *location, const char *action,
  *     {
  *         matches = [
  *             # any of the items in matches needs to match, if one does,
- *             # actions are emited.
+ *             # actions are emitted.
  *             {
  *                 # all keys must match the value. ! negates. ~ starts regex.
  *                 <key> = <value>

--- a/lib/wp/log.c
+++ b/lib/wp/log.c
@@ -21,7 +21,7 @@ WP_DEFINE_LOCAL_LOG_TOPIC ("wp-log")
  * \def WP_DEFINE_LOCAL_LOG_TOPIC(name)
  * \brief Defines a static \em WpLogTopic* variable called \em WP_LOCAL_LOG_TOPIC
  *
- * The log topic is automatically intialized to the given topic \a name when
+ * The log topic is automatically initialized to the given topic \a name when
  * it is first used. The default logging macros expect this variable to be
  * defined, so it is a good coding practice in the WirePlumber codebase to
  * start all files at the top with:

--- a/lib/wp/metadata.c
+++ b/lib/wp/metadata.c
@@ -41,7 +41,7 @@ WP_DEFINE_LOCAL_LOG_TOPIC ("wp-metadata")
  *                   gchar * value,
  *                   gpointer user_data)
  * \endcode
- * Emited when metadata change
+ * Emitted when metadata change
  *
  * Parameters:
  * - `subject` - the metadata subject id

--- a/lib/wp/object-interest.c
+++ b/lib/wp/object-interest.c
@@ -81,7 +81,7 @@ G_DEFINE_BOXED_TYPE (WpObjectInterest, wp_object_interest,
  * For further reading on the constraint's arguments, see
  * wp_object_interest_add_constraint()
  *
- * For example, this interest matches objects that are descendands of WpProxy
+ * For example, this interest matches objects that are descendants of WpProxy
  * with a "bound-id" between 0 and 100 (inclusive), with a pipewire property
  * called "format.dsp" that contains the string "audio" somewhere in the value
  * and with a pipewire property "port.name" being present (with any value):

--- a/lib/wp/object-interest.h
+++ b/lib/wp/object-interest.h
@@ -85,7 +85,7 @@ typedef enum { /*< flags >*/
  */
 typedef enum { /*< flags >*/
   WP_INTEREST_MATCH_FLAGS_NONE = 0,
-  /*! check all the constraints instead of returning after the first mis-match */
+  /*! check all the constraints instead of returning after the first mismatch */
   WP_INTEREST_MATCH_FLAGS_CHECK_ALL = (1 << 0),
 } WpInterestMatchFlags;
 

--- a/lib/wp/object-manager.c
+++ b/lib/wp/object-manager.c
@@ -587,7 +587,7 @@ wp_object_manager_lookup (WpObjectManager * self, GType gtype, ...)
  *
  * \ingroup wpobjectmanager
  * \param self the object manager
- * \param interest (transfer full): the interst
+ * \param interest (transfer full): the interest
  * \returns (type GObject)(transfer full)(nullable): the first managed object
  *    that matches the lookup interest, or NULL if no object matches
  */

--- a/lib/wp/plugin.c
+++ b/lib/wp/plugin.c
@@ -198,7 +198,7 @@ wp_plugin_find (WpCore * core, const gchar * plugin_name)
 }
 
 /*!
- * \brief Retreives the name of a plugin.
+ * \brief Retrieves the name of a plugin.
  *
  * \ingroup wpplugin
  * \param self the plugin

--- a/lib/wp/properties.c
+++ b/lib/wp/properties.c
@@ -203,7 +203,7 @@ wp_properties_new_wrap (const struct pw_properties * props)
  * allowing reading & writing properties on that \a props structure through
  * the WpProperties API.
  *
- * In constrast with wp_properties_new_wrap(), this function assumes ownership
+ * In contrast with wp_properties_new_wrap(), this function assumes ownership
  * of the \a props structure, so it will try to free \a props when it is destroyed.
  *
  * \ingroup wpproperties
@@ -1036,7 +1036,7 @@ wp_properties_unref_and_take_pw_properties (WpProperties * self)
  * \ingroup wpproperties
  * \param self a properties object
  * \param other a set of properties to match
- * \returns TRUE if all matches were successfull, FALSE if at least one
+ * \returns TRUE if all matches were successful, FALSE if at least one
  *   property value did not match
  */
 gboolean

--- a/lib/wp/proxy-interfaces.c
+++ b/lib/wp/proxy-interfaces.c
@@ -82,7 +82,7 @@ wp_pipewire_object_default_init (WpPipewireObjectInterface * iface)
 }
 
 /*!
- * \brief Retrieves the native infor structure of this object
+ * \brief Retrieves the native info structure of this object
  * (pw_node_info, pw_port_info, etc...)
  *
  * \remark Requires WP_PIPEWIRE_OBJECT_FEATURE_INFO

--- a/lib/wp/session-item.c
+++ b/lib/wp/session-item.c
@@ -407,7 +407,7 @@ on_session_item_proxy_destroyed_deferred (WpSessionItem * item)
 }
 
 /*!
- * \brief Helper callback for sub-classes that deffers and unexports
+ * \brief Helper callback for sub-classes that defers and unexports
  * the session item.
  *
  * Only meant to be used when the pipewire proxy destroyed signal is triggered.

--- a/lib/wp/spa-json.c
+++ b/lib/wp/spa-json.c
@@ -580,7 +580,7 @@ wp_spa_json_new_object_valist (const gchar *key, const gchar *format,
 }
 
 /*!
- * \brief Checks wether the spa json is of type null or not
+ * \brief Checks whether the spa json is of type null or not
  *
  * \ingroup wpspajson
  * \param self the spa json object
@@ -593,7 +593,7 @@ wp_spa_json_is_null (WpSpaJson *self)
 }
 
 /*!
- * \brief Checks wether the spa json is of type boolean or not
+ * \brief Checks whether the spa json is of type boolean or not
  *
  * \ingroup wpspajson
  * \param self the spa json object
@@ -606,7 +606,7 @@ wp_spa_json_is_boolean (WpSpaJson *self)
 }
 
 /*!
- * \brief Checks wether the spa json is of type int or not
+ * \brief Checks whether the spa json is of type int or not
  *
  * \ingroup wpspajson
  * \param self the spa json object
@@ -619,7 +619,7 @@ wp_spa_json_is_int (WpSpaJson *self)
 }
 
 /*!
- * \brief Checks wether the spa json is of type float or not
+ * \brief Checks whether the spa json is of type float or not
  *
  * \ingroup wpspajson
  * \param self the spa json object
@@ -632,7 +632,7 @@ wp_spa_json_is_float (WpSpaJson *self)
 }
 
 /*!
- * \brief Checks wether the spa json is of type string or not
+ * \brief Checks whether the spa json is of type string or not
  *
  * \ingroup wpspajson
  * \param self the spa json object

--- a/lib/wp/spa-pod.c
+++ b/lib/wp/spa-pod.c
@@ -797,7 +797,7 @@ wp_spa_pod_new_sequence_valist (guint unit, va_list args)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type none or not
+ * \brief Checks whether the spa pod is of type none or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -810,7 +810,7 @@ wp_spa_pod_is_none (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type boolean or not
+ * \brief Checks whether the spa pod is of type boolean or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -823,7 +823,7 @@ wp_spa_pod_is_boolean (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type Id or not
+ * \brief Checks whether the spa pod is of type Id or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -836,7 +836,7 @@ wp_spa_pod_is_id (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type int or not
+ * \brief Checks whether the spa pod is of type int or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -849,7 +849,7 @@ wp_spa_pod_is_int (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type long or not
+ * \brief Checks whether the spa pod is of type long or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -862,7 +862,7 @@ wp_spa_pod_is_long (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type float or not
+ * \brief Checks whether the spa pod is of type float or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -875,7 +875,7 @@ wp_spa_pod_is_float (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type double or not
+ * \brief Checks whether the spa pod is of type double or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -888,7 +888,7 @@ wp_spa_pod_is_double (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type string or not
+ * \brief Checks whether the spa pod is of type string or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -901,7 +901,7 @@ wp_spa_pod_is_string (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type bytes or not
+ * \brief Checks whether the spa pod is of type bytes or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -914,7 +914,7 @@ wp_spa_pod_is_bytes (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type pointer or not
+ * \brief Checks whether the spa pod is of type pointer or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -927,7 +927,7 @@ wp_spa_pod_is_pointer (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type Fd or not
+ * \brief Checks whether the spa pod is of type Fd or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -940,7 +940,7 @@ wp_spa_pod_is_fd (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type rectangle or not
+ * \brief Checks whether the spa pod is of type rectangle or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -953,7 +953,7 @@ wp_spa_pod_is_rectangle (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type fraction or not
+ * \brief Checks whether the spa pod is of type fraction or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -966,7 +966,7 @@ wp_spa_pod_is_fraction (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type array or not
+ * \brief Checks whether the spa pod is of type array or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -979,7 +979,7 @@ wp_spa_pod_is_array (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type choice or not
+ * \brief Checks whether the spa pod is of type choice or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -992,7 +992,7 @@ wp_spa_pod_is_choice (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type object or not
+ * \brief Checks whether the spa pod is of type object or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -1005,7 +1005,7 @@ wp_spa_pod_is_object (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type struct or not
+ * \brief Checks whether the spa pod is of type struct or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -1018,7 +1018,7 @@ wp_spa_pod_is_struct (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type sequence or not
+ * \brief Checks whether the spa pod is of type sequence or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -1031,7 +1031,7 @@ wp_spa_pod_is_sequence (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type property or not
+ * \brief Checks whether the spa pod is of type property or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -1044,7 +1044,7 @@ wp_spa_pod_is_property (WpSpaPod *self)
 }
 
 /*!
- * \brief Checks wether the spa pod is of type control or not
+ * \brief Checks whether the spa pod is of type control or not
  *
  * \ingroup wpspapod
  * \param self the spa pod object
@@ -1438,7 +1438,7 @@ wp_spa_pod_set_rectangle (WpSpaPod *self, guint32 width, guint32 height)
  *
  * \ingroup wpspapod
  * \param self the spa pod object
- * \param num the numerator value of the farction
+ * \param num the numerator value of the fraction
  * \param denom the denominator value of the fraction
  * \returns TRUE if the value could be set, FALSE othewrise.
  */
@@ -1820,7 +1820,7 @@ wp_spa_pod_fixate (WpSpaPod *self)
  * \brief Returns the intersection between \a self and \a filter
  *
  * This is typically used to intersect pods that describe formats, in order to
- * find a common format that is accceptable by both sides. For that purpose,
+ * find a common format that is acceptable by both sides. For that purpose,
  * this is not exactly an intersection with its mathematical meaning.
  * Object properties can be thought of as format constraints. When one side does
  * not specify a specific property, it is considered to accept any value for it,
@@ -2117,7 +2117,7 @@ wp_spa_pod_builder_add_bytes (WpSpaPodBuilder *self, gconstpointer value,
  * \ingroup wpspapod
  * \param self the spa pod builder object
  * \param type_name the type name that the pointer points to
- * \param value the pointer vaue
+ * \param value the pointer value
  */
 void
 wp_spa_pod_builder_add_pointer (WpSpaPodBuilder *self, const char *type_name,

--- a/modules/module-lua-scripting/script.c
+++ b/modules/module-lua-scripting/script.c
@@ -19,7 +19,7 @@ WP_LOG_TOPIC_EXTERN (log_topic_lua_scripting)
  * to declare when it has finished its activation procedure, which can be
  * asynchronous (this is Script.finish_activation in Lua).
  * When disabled, this class destroys the global environment that was used
- * in the Lua engine for excecuting that script, effectively destroying all
+ * in the Lua engine for executing that script, effectively destroying all
  * objects that were held in Lua as global variables.
  */
 

--- a/modules/module-lua-scripting/wplua/sandbox.lua
+++ b/modules/module-lua-scripting/wplua/sandbox.lua
@@ -62,7 +62,7 @@ function create_sandbox_env()
 end
 
 if SANDBOX_CONFIG["isolate_env"] then
-  -- in isolate_env mode, use a separate enviornment for each loaded chunk and
+  -- in isolate_env mode, use a separate environment for each loaded chunk and
   -- store all of them in a global table so that they are not garbage collected
   SANDBOX_ENV_LIST = {}
 

--- a/modules/module-si-standard-link.c
+++ b/modules/module-si-standard-link.c
@@ -149,7 +149,7 @@ clear_node_links (GPtrArray **node_links_p)
 {
   /*
    * Something else (eg. object managers) may be keeping the WpLink
-   * objects alive. Deactive the links now, to destroy the PW objects.
+   * objects alive. Deactivate the links now, to destroy the PW objects.
    */
   if (*node_links_p)
     g_ptr_array_foreach (*node_links_p, request_destroy_link, NULL);

--- a/src/scripts/default-nodes/find-selected-default-node.lua
+++ b/src/scripts/default-nodes/find-selected-default-node.lua
@@ -4,11 +4,11 @@
 --
 -- SPDX-License-Identifier: MIT
 
--- hook to make sure the user prefered device(default.configured.*) in other
+-- hook to make sure the user preferred device(default.configured.*) in other
 -- words currently selected device is given higher priority
 
 -- state-default-nodes.lua also does find out the default node out of the user
--- preferences(current and past), however it doesnt give any higher priority to
+-- preferences(current and past), however it doesn't give any higher priority to
 -- the currently selected device.
 
 log = Log.open_topic ("s-default-nodes")

--- a/src/scripts/default-nodes/state-default-nodes.lua
+++ b/src/scripts/default-nodes/state-default-nodes.lua
@@ -6,7 +6,7 @@
 
 -- the script states the default nodes from the user preferences, it has hooks
 -- which stores the user preferences(it stores not just the current preference
--- but all the previous preferences) in to the state file, retrives them from
+-- but all the previous preferences) in to the state file, retrieves them from
 -- state file during the bootup, finally it has a hook which finds a default
 -- node out of the user preferences
 
@@ -90,7 +90,7 @@ store_configured_default_nodes_hook = SimpleEventHook {
       local stored = collectStored (def_node_type)
       local pos = #stored + 1
 
-      -- find if the curent configured value is already in the stack
+      -- find if the current configured value is already in the stack
       for i, v in ipairs (stored) do
         if v == new_value then
           pos = i

--- a/src/scripts/linking/find-best-target.lua
+++ b/src/scripts/linking/find-best-target.lua
@@ -85,7 +85,7 @@ SimpleEventHook {
 
       log:debug ("... priority:" .. tostring (priority) .. ", plugged:" .. tostring (plugged))
 
-      -- (target_picked == NULL) --> make sure atleast one target is picked.
+      -- (target_picked == NULL) --> make sure at least one target is picked.
       -- (priority > target_priority) --> pick the highest priority linkable(node)
       -- target.
       -- (priority == target_priority and plugged > target_plugged) --> pick the

--- a/src/scripts/linking/find-defined-target.lua
+++ b/src/scripts/linking/find-defined-target.lua
@@ -5,7 +5,7 @@
 -- SPDX-License-Identifier: MIT
 --
 -- Check if the target node is defined explicitly.
--- This defination can be done in two ways.
+-- This definition can be done in two ways.
 -- 1. "node.target"/"target.object" in the node properties
 -- 2. "target.node"/"target.object" in the default metadata
 

--- a/src/scripts/linking/rescan-media-role-links.lua
+++ b/src/scripts/linking/rescan-media-role-links.lua
@@ -35,7 +35,7 @@ function setVolume (om, link, level)
   }
 
   -- apply volume control on the stream node of the loopback module, instead of
-  -- the sink/source node as it simplyfies the volume ducking and
+  -- the sink/source node as it simplifies the volume ducking and
   -- restoration.
   local media_role_other_lnkbl = om:lookup {
     type = "SiLinkable",

--- a/src/scripts/monitors/alsa.lua
+++ b/src/scripts/monitors/alsa.lua
@@ -37,7 +37,7 @@ function createNode(parent, id, obj_type, factory, properties)
   -- set the default pause-on-idle setting
   properties["node.pause-on-idle"] = false
 
-  -- try to negotiate the max ammount of channels
+  -- try to negotiate the max amount of channels
   if dev_props["api.alsa.use-acp"] ~= "true" then
     properties["audio.channels"] = properties["audio.channels"] or "64"
   end

--- a/tests/modules/si-node.c
+++ b/tests/modules/si-node.c
@@ -73,7 +73,7 @@ test_si_node_configure_activate (TestFixture * f, gconstpointer user_data)
   g_autoptr (WpNode) node = NULL;
   g_autoptr (WpSessionItem) item = NULL;
 
-  /* skip test if spa factory is not insalled */
+  /* skip test if spa factory is not installed */
   if (!test_is_spa_lib_installed (&f->base, data->factory)) {
     g_autofree gchar *msg = NULL;
     msg = g_strdup_printf ("The pipewire %s factory was not found",

--- a/tests/scripts/scripts/12-test-linking-defined-device-node-target-node-metadata.lua
+++ b/tests/scripts/scripts/12-test-linking-defined-device-node-target-node-metadata.lua
@@ -29,7 +29,7 @@ SimpleEventHook {
     local name = lnkbl.properties ["node.name"]
 
     if tu.linkablesReady () and name ~= "stream-node" then
-      -- all linkables created execept stream-node
+      -- all linkables created except stream-node
       tu.createStreamNode ("playback")
     elseif tu.linkablesReady () and tu.lnkbls ["stream-node"] then
       -- when "stream-node" linkable is ready
@@ -38,7 +38,7 @@ SimpleEventHook {
   end
 }:register ()
 
--- hook to selet defined target
+-- hook to select defined target
 SimpleEventHook {
   name = "linkable-added@test-linking",
   after = "linkable-added@test-utils-linking",

--- a/tests/scripts/scripts/13-test-linking-defined-device-node-target-node-metadata-capture.lua
+++ b/tests/scripts/scripts/13-test-linking-defined-device-node-target-node-metadata-capture.lua
@@ -29,7 +29,7 @@ SimpleEventHook {
     local name = lnkbl.properties ["node.name"]
 
     if tu.linkablesReady () and name ~= "stream-node" then
-      -- all linkables created execept stream-node
+      -- all linkables created except stream-node
       tu.createStreamNode ("capture")
     elseif tu.linkablesReady () and tu.lnkbls ["stream-node"] then
       -- when "stream-node" linkable is ready

--- a/tests/scripts/scripts/14-test-linking-defined-device-node-target-object-metadata.lua
+++ b/tests/scripts/scripts/14-test-linking-defined-device-node-target-object-metadata.lua
@@ -29,7 +29,7 @@ SimpleEventHook {
     local name = lnkbl.properties ["node.name"]
 
     if tu.linkablesReady () and name ~= "stream-node" then
-      -- all linkables created execept stream-node
+      -- all linkables created except stream-node
       tu.createStreamNode ("playback")
     elseif tu.linkablesReady () and tu.lnkbls ["stream-node"] then
       -- when "stream-node" linkable is ready

--- a/tests/scripts/scripts/15-test-linking-defined-device-node-target-object-metadata-capture.lua
+++ b/tests/scripts/scripts/15-test-linking-defined-device-node-target-object-metadata-capture.lua
@@ -29,7 +29,7 @@ SimpleEventHook {
     local name = lnkbl.properties ["node.name"]
 
     if tu.linkablesReady () and name ~= "stream-node" then
-      -- all linkables created execept stream-node
+      -- all linkables created except stream-node
       tu.createStreamNode ("capture")
     elseif tu.linkablesReady () and tu.lnkbls ["stream-node"] then
       -- when "stream-node" linkable is ready

--- a/tests/scripts/scripts/16-test-linking-defined-device-node-target-object-int-metadata.lua
+++ b/tests/scripts/scripts/16-test-linking-defined-device-node-target-object-int-metadata.lua
@@ -30,7 +30,7 @@ SimpleEventHook {
     local name = lnkbl.properties ["node.name"]
 
     if tu.linkablesReady () and name ~= "stream-node" then
-      -- all linkables created execept stream-node
+      -- all linkables created except stream-node
       local props = {
         ["target.object"] = tu.lnkbls ["defined-device-node-in-props"].properties ["node.id"]
       }

--- a/tests/scripts/scripts/17-test-linking-defined-device-node-target-object-int-metadata-capture.lua
+++ b/tests/scripts/scripts/17-test-linking-defined-device-node-target-object-int-metadata-capture.lua
@@ -30,7 +30,7 @@ SimpleEventHook {
     local name = lnkbl.properties ["node.name"]
 
     if tu.linkablesReady () and name ~= "stream-node" then
-      -- all linkables created execept stream-node
+      -- all linkables created except stream-node
       local props = {
         ["target.object"] = tu.lnkbls ["defined-device-node-in-props"].properties ["node.id"]
       }


### PR DESCRIPTION
Found via `codespell -q 3 -S "*.po,./po/*,NEWS.rst" -L bootup,gir,inout`

Apologies for not making the MR in gitlab but I'm having credential and permission issues in gitlab.  
Also, feel free to cherrypick or even redo this PR. I remove any ownership of it. 